### PR TITLE
Add more logging for errors to the bot

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -309,6 +309,7 @@ function setupDiscord(dropbox, db) {
     execute: async (message, args) => {
       console.log("args", args)
       if (args._.length === 0) {
+        await message.reply(`Failed to add a sampple, missing URL`)
         return message.react('❓')
       }
 
@@ -320,6 +321,8 @@ function setupDiscord(dropbox, db) {
         console.error(err)
         if (err.error) {
           await message.reply(`Failed to add a sample: \`\`\`${JSON.stringify(err.error, null, 2)}\`\`\``)
+        } else {
+          await message.reply(`Failed to add a sample: ${err.toString()}`)
         }
         return message.react('❓')
       }


### PR DESCRIPTION
This pull request adds more error logging to the bot, in case it isn't coming from the YouTube module, we can see what went wrong without having to access the box.