### PR TITLE
Always lowercase message for checks.

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -351,7 +351,8 @@ function setupDiscord(dropbox, db) {
   client.on('message', (message) =>
     (async () => {
       if (message.author.bot) return
-      let argv = message.content.split(/ +/)
+      let content = message.content.toLowerCase()
+      let argv = content.split(/ +/)
       if (!argv[0].startsWith(prefix)) return
       argv[0] = argv[0].substr(prefix.length)
       let args = parseArgs(argv)


### PR DESCRIPTION
This makes a call for `toLowercase()` on the message contents, so we can have case-insensitive commands. 